### PR TITLE
Bugfix/fix shared library build on msvc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ gtest/Makefile
 gtest/config.log
 gtest/config.status
 gtest/libtool
+
+# biicode simple layout
+/bii
+/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,6 @@ script:
 - mkdir -p ./biicode_project/blocks/google/gmock
 - mv !(biicode_project) ./biicode_project/blocks/google/gmock
 - cd biicode_project
-- bii build --target biitest
+- bii configure -Dgmock_build_tests=ON
+- bii build
+- bii build --target test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,22 @@ endif()
   ############################################################
   # C++ tests built with standard compiler flags.
 
+if (BIICODE)
+  include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/biicode_utils.cmake)
+
+  # gmock_output_test_ deliberately fails, and is meant for testing the failure output of gmock
+  bii_cxx_test(gmock-actions_test gmock_main)
+  bii_cxx_test(gmock-cardinalities_test gmock_main)
+  bii_cxx_test(gmock_ex_test gmock_main)
+  bii_cxx_test(gmock-generated-actions_test gmock_main)
+  bii_cxx_test(gmock-generated-function-mockers_test gmock_main)
+  bii_cxx_test(gmock-generated-internal-utils_test gmock_main)
+  bii_cxx_test(gmock-generated-matchers_test gmock_main)
+
+  if (CMAKE_USE_PTHREADS_INIT)
+    bii_cxx_test(gmock_stress_test gmock)
+  endif()
+else()
   cxx_test(gmock-actions_test gmock_main)
   cxx_test(gmock-cardinalities_test gmock_main)
   cxx_test(gmock_ex_test gmock_main)
@@ -114,10 +130,11 @@ endif()
   cxx_test(gmock-generated-internal-utils_test gmock_main)
   cxx_test(gmock-generated-matchers_test gmock_main)
 
-
   if (CMAKE_USE_PTHREADS_INIT)
     cxx_test(gmock_stress_test gmock)
   endif()
+endif()
+
 endif()
 
 MESSAGE("CMAKE_USE_PTHREADS_INIT ${CMAKE_USE_PTHREADS_INIT}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 #
 ###########################################################################
 # Actually create targets: EXEcutables and libraries.
-ADD_BIICODE_TARGETS()
+ADD_BII_TARGETS()
 
 IF(BII_BLOCK_TARGET)
   TARGET_INCLUDE_DIRECTORIES(${BII_BLOCK_TARGET} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
@@ -81,6 +81,11 @@ cxx_library(gmock_main
             "${gtest_dir}/src/gtest-all.cc"
             src/gmock-all.cc
             src/gmock_main.cc)
+
+if (BIICODE)
+  TARGET_INCLUDE_DIRECTORIES(gmock PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+  TARGET_INCLUDE_DIRECTORIES(gmock_main PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+endif()
 
 ########################################################################
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,16 +5,6 @@
 #     If you want check the original CMakeLists.txt, see CMakeLists.txt
 #
 ###########################################################################
-# Actually create targets: EXEcutables and libraries.
-ADD_BII_TARGETS()
-
-IF(BII_BLOCK_TARGET)
-  TARGET_INCLUDE_DIRECTORIES(${BII_BLOCK_TARGET} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
-  TARGET_INCLUDE_DIRECTORIES(${BII_BLOCK_TARGET} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
-ELSE()
-  INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
-  INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/include)
-ENDIF()
 
 ########################################################################
 # CMake build script for Google Mock.
@@ -60,6 +50,40 @@ endif()
 # call it again here.
 config_compiler_and_linker()  # from ${gtest_dir}/cmake/internal_utils.cmake
 
+########################################################################
+
+# To allow GMock to be built as a shared library with MSVC, we have to
+# compile it together with GTest sources, so we extract the sources and add
+# it to BII_LIB_SRC
+list(REMOVE_ITEM BII_LIB_DEPS google_gtest)
+get_property(gtest_sources TARGET google_gtest PROPERTY SOURCES)
+
+# We can't just append the relative path gtest source files to BII_LIB_SRC
+# and include_directories(${gtest_dir}), as the add_library()...) cmake
+# function (used by biicode) expects all files specified in BII_LIB_SRC to
+# be relative to the current source directory
+set(gtest_sources_abs )
+foreach(src ${gtest_sources})
+  list(APPEND gtest_sources_abs "${gtest_dir}/${src}")
+endforeach()
+
+set(BII_LIB_SRC ${BII_LIB_SRC} ${gtest_sources_abs})
+
+# Actually create targets: EXEcutables and libraries.
+ADD_BII_TARGETS()
+
+if(BUILD_SHARED_LIBS)
+  target_compile_definitions(${BII_LIB_TARGET} PRIVATE "-DGTEST_CREATE_SHARED_LIBRARY=1"
+                                               INTERFACE "-DGTEST_LINKED_AS_SHARED_LIBRARY=1")
+endif()
+
+IF(BII_BLOCK_TARGET)
+  TARGET_INCLUDE_DIRECTORIES(${BII_BLOCK_TARGET} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+  TARGET_INCLUDE_DIRECTORIES(${BII_BLOCK_TARGET} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+ELSE()
+  INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
+  INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/include)
+ENDIF()
 
 if (gmock_build_tests)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,17 @@ endforeach()
 
 set(BII_LIB_SRC ${BII_LIB_SRC} ${gtest_sources_abs})
 
+if (MSVC)
+  # Disable C4251 warnings as STL templates are not exported as part of
+  # the GMock library when building a shared library
+  #
+  # WARNING: This is only here because there is enough confidence that
+  # all template members in GMock's exported interfaces are from the STL.
+  foreach(src ${BII_LIB_SRC})
+    set_source_files_properties(${src} PROPERTIES COMPILE_FLAGS "/wd4251")
+  endforeach()
+endif()
+
 # Actually create targets: EXEcutables and libraries.
 ADD_BII_TARGETS()
 

--- a/biicode.conf
+++ b/biicode.conf
@@ -2,7 +2,7 @@
 
 [requirements]
 	# This file contains your block external dependencies references
-	google/gtest: 10
+	google/gtest: 11
 
 [parent]
 	google/gmock: 2

--- a/biicode.conf
+++ b/biicode.conf
@@ -20,4 +20,4 @@
 	!test/gmock_stress_test.cc
 
 [tests]
-	test/*
+	test/* - test/gmock_output_test_.cc

--- a/cmake/biicode_utils.cmake
+++ b/cmake/biicode_utils.cmake
@@ -1,0 +1,18 @@
+# bii_cxx_test_with_flags(name cxx_flags libs srcs...)
+#
+# creates a named C++ test that depends on the given libs and is built
+# from the given source files with the given compiler flags.
+function(bii_cxx_test_with_flags name cxx_flags libs)
+  cxx_executable_with_flags(${name} "${cxx_flags}" "${libs}" ${ARGN})
+  add_test(${name} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${name})
+endfunction()
+
+# bii_cxx_test(name libs srcs...)
+#
+# creates a named test target that depends on the given libs and is
+# built from the given source files.  Unlike bii_cxx_test_with_flags,
+# test/name.cc is already implicitly included in the source file list.
+function(bii_cxx_test name libs)
+  bii_cxx_test_with_flags("${name}" "${cxx_default}" "${libs}"
+    "test/${name}.cc" ${ARGN})
+endfunction()

--- a/test/gmock-generated-function-mockers_test.cc
+++ b/test/gmock-generated-function-mockers_test.cc
@@ -112,6 +112,10 @@ class FooInterface {
 #endif  // GTEST_OS_WINDOWS
 };
 
+#ifdef GMOCK_ALLOWS_CONST_PARAM_FUNCTIONS
+  #pragma warning(push)
+  #pragma warning(disable:4373)
+#endif
 class MockFoo : public FooInterface {
  public:
   MockFoo() {}
@@ -167,6 +171,9 @@ class MockFoo : public FooInterface {
  private:
   GTEST_DISALLOW_COPY_AND_ASSIGN_(MockFoo);
 };
+#ifdef GMOCK_ALLOWS_CONST_PARAM_FUNCTIONS
+  #pragma warning(pop)
+#endif
 
 class FunctionMockerTest : public testing::Test {
  protected:


### PR DESCRIPTION
I've modified CMakeLists.txt to allow GMock to be built as a shared library on Windows using MSVC.

I've also added a bii_cxx_test function to allow biicode builds to build the GMock tests, with `bii build --target test`. This has also been changed in .travis.yml.

The last commit suppresses around half of the C4251 warnings that MSVC outputs (~580 to around ~270, number are approximate as I had my own block present). I suspect most of those are from gtest's block, as well as some C4275 warnings (subclassing from std::runtime_error which is not a class exported from GMock).