### PR TITLE
Bugfix/fix shared library build with clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,21 +55,25 @@ config_compiler_and_linker()  # from ${gtest_dir}/cmake/internal_utils.cmake
 # To allow GMock to be built as a shared library with MSVC, we have to
 # compile it together with GTest sources, so we extract the sources and add
 # it to BII_LIB_SRC
-list(REMOVE_ITEM BII_LIB_DEPS google_gtest)
-get_property(gtest_sources TARGET google_gtest PROPERTY SOURCES)
-
-# We can't just append the relative path gtest source files to BII_LIB_SRC
-# and include_directories(${gtest_dir}), as the add_library()...) cmake
-# function (used by biicode) expects all files specified in BII_LIB_SRC to
-# be relative to the current source directory
-set(gtest_sources_abs )
-foreach(src ${gtest_sources})
-  list(APPEND gtest_sources_abs "${gtest_dir}/${src}")
-endforeach()
-
-set(BII_LIB_SRC ${BII_LIB_SRC} ${gtest_sources_abs})
-
+#
+# If we are building with clang, we must NOT set gtest sources as part of gmock
+# otherwise on Debian systems, tests that link against both gtest and gmock
+# will encounter a 'double free or corruption' error
 if (MSVC)
+  list(REMOVE_ITEM BII_LIB_DEPS google_gtest)
+  get_property(gtest_sources TARGET google_gtest PROPERTY SOURCES)
+
+  # We can't just append the relative path gtest source files to BII_LIB_SRC
+  # and include_directories(${gtest_dir}), as the add_library()...) cmake
+  # function (used by biicode) expects all files specified in BII_LIB_SRC to
+  # be relative to the current source directory
+  set(gtest_sources_abs )
+  foreach(src ${gtest_sources})
+    list(APPEND gtest_sources_abs "${gtest_dir}/${src}")
+  endforeach()
+
+  set(BII_LIB_SRC ${BII_LIB_SRC} ${gtest_sources_abs})
+
   # Disable C4251 warnings as STL templates are not exported as part of
   # the GMock library when building a shared library
   #

--- a/biicode.conf
+++ b/biicode.conf
@@ -5,7 +5,7 @@
 	google/gtest: 11
 
 [parent]
-	google/gmock: 2
+	google/gmock: 3
 
 [paths]
 	/include


### PR DESCRIPTION
Encountered an issue when building my project in the following environment:
- compiler: clang 3.4 (or 3.6)
- OS: Ubuntu 14.04
- BUILD_SHARED_LIBS=ON

Error from my tests:

```
*** Error in `/usr/dev/bii/autexousious-build/bin/azriel_sl_core_application_test_main': double free or corruption (!prev): 0x00000000014da730 ***
```

The `(!prev)` sometimes is `(top)` depending on how the code changes, in case someone else finds this ticket.

Symptoms appear to be the same as: https://code.google.com/p/yaml-cpp/issues/detail?id=279
